### PR TITLE
feat: add c4_person shape support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,25 @@ When set on an `element` style, adds [fill pattern](https://d2lang.com/tour/styl
 Source: [fill-pattern/workspace.dsl](lib/src/test/resources/fill-pattern/workspace.dsl)
 
 ![fill-pattern.png](examples/fill-pattern.png)
+
+## `d2.useC4Person` (experimental)
+
+* Entity: [`views`, `view`](https://github.com/structurizr/dsl/blob/master/docs/language-reference.md#views)
+* Values: `true`, `false`
+* Default: `false`
+
+Uses d2 `c4_person` shape for structurizr `Person` and `Robot`.
+
+**Hint:**
+* Verify if your d2 version supports `c4_person`, see https://github.com/terrastruct/d2/pull/2397.
+* In structurizr `Person` elements' default shape is `Box`. Use a custom style for a `Person` shape:
+```
+  views {
+      styles {
+          # structurizr uses retangle shapes for Person by default
+          element "Person" {
+              shape Person
+          }
+      }
+  }
+```

--- a/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/D2Exporter.kt
+++ b/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/D2Exporter.kt
@@ -13,6 +13,7 @@ import io.github.goto1134.structurizr.export.d2.model.TextObject
 open class D2Exporter : AbstractDiagramExporter() {
 
     companion object {
+        const val D2_USE_C4_PERSON = "d2.use_c4_person"
         const val D2_TITLE_POSITION = "d2.title_position"
         const val D2_ANIMATION = "d2.animation"
         const val D2_CONNECTION_ANIMATED = "d2.animated"
@@ -229,7 +230,7 @@ open class D2Exporter : AbstractDiagramExporter() {
         val currentGroupStyle = view.viewSet.configuration.styles.findElementStyle("Group:${groupWithPath.fullGroup}")
         NamedObject.build(groupWithPath.absolutePathInView(view)) {
             label(groupWithPath.group)
-            shape(currentGroupStyle?.d2Shape ?: allGroupsStyle?.d2Shape ?: D2Shape.RECTANGLE)
+            shape(currentGroupStyle?.let { d2Shape(view, it) } ?: allGroupsStyle?.let { d2Shape(view, it) } ?: D2Shape.RECTANGLE)
             icon(currentGroupStyle?.icon ?: allGroupsStyle?.icon)
             stroke(currentGroupStyle?.stroke ?: currentGroupStyle?.stroke ?: "#cccccc")
             strokeWidth(currentGroupStyle?.strokeWidth ?: allGroupsStyle?.strokeWidth ?: 2)
@@ -299,7 +300,7 @@ open class D2Exporter : AbstractDiagramExporter() {
         val style = findElementStyle(view, this)
         NamedObject.build(absolutePathInView(view)) {
             label(d2Label(view))
-            shape(style.d2Shape)
+            shape(d2Shape(view, style))
             icon(style.icon)
             link(url)
             tooltip(description)

--- a/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/ElementExt.kt
+++ b/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/ElementExt.kt
@@ -9,13 +9,14 @@ import io.github.goto1134.structurizr.export.d2.D2Exporter.Companion.STRUCTURIZR
 import io.github.goto1134.structurizr.export.d2.model.D2FillPattern
 import io.github.goto1134.structurizr.export.d2.model.D2Shape
 
-val ElementStyle.d2Opacity get() = opacity?.toDouble()?.div( 100)
+val ElementStyle.d2Opacity get() = opacity?.toDouble()?.div(100)
 
 val ElementStyle.d2FillPattern get() = D2FillPattern.get(properties[D2Exporter.D2_FILL_PATTERN])
 
-val ElementStyle.d2Shape
-    get() = when (shape) {
-        Shape.Person, Shape.Robot -> D2Shape.PERSON
+
+fun d2Shape(view: View, style: ElementStyle): D2Shape? {
+    return when (style.shape) {
+        Shape.Person, Shape.Robot -> if (view.d2UseC4Person) D2Shape.C4_PERSON else D2Shape.PERSON
         Shape.Cylinder -> D2Shape.CYLINDER
         Shape.Folder -> D2Shape.PACKAGE
         Shape.Ellipse -> D2Shape.OVAL
@@ -26,6 +27,7 @@ val ElementStyle.d2Shape
         null -> null
         else -> D2Shape.RECTANGLE
     }
+}
 
 val Element.d2Id get() = "container_$id"
 
@@ -73,7 +75,7 @@ val Element.hasMultipleInstances get() = this is DeploymentNode && "1" != instan
 fun Element.inViewNotRoot(view: ModelView) = (view !is ContainerView || this is Container) && view.isElementInView(this)
 
 fun Element.inViewOrRoot(view: ModelView): Boolean {
-    return view is ComponentView &&  equals(view.container)
+    return view is ComponentView && equals(view.container)
             || view is ContainerView && (this !is Container || equals(view.softwareSystem))
             || view is DynamicView && equals(view.element)
             || inViewNotRoot(view)

--- a/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/ViewExt.kt
+++ b/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/ViewExt.kt
@@ -11,6 +11,9 @@ import io.github.goto1134.structurizr.export.d2.model.D2NearConstant.TOP_CENTER
 
 fun View.getViewOrViewSetProperty(key: String) = properties.getOrElse(key) { viewSet.configuration.properties[key] }
 
+val View.d2UseC4Person: Boolean
+    get() = getViewOrViewSetProperty(D2Exporter.D2_USE_C4_PERSON).toBoolean()
+
 val View.d2Title: String
     get() = title?.takeUnless(String::isBlank) ?: name
 

--- a/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/model/D2Shape.kt
+++ b/lib/src/main/kotlin/io/github/goto1134/structurizr/export/d2/model/D2Shape.kt
@@ -19,6 +19,7 @@ enum class D2Shape(private val value: String) {
     CALLOUT("callout"),
     STORED_DATA("stored_data"),
     PERSON("person"),
+    C4_PERSON("c4_person"),
     DIAMOND("diamond"),
     OVAL("oval"),
     CIRCLE("circle"),

--- a/lib/src/test/kotlin/io/github/goto1134/structurizr/export/d2/D2ExporterTest.kt
+++ b/lib/src/test/kotlin/io/github/goto1134/structurizr/export/d2/D2ExporterTest.kt
@@ -126,4 +126,22 @@ internal class D2ExporterTest {
         assertEquals(2, diagrams.size)
         assertAllDiagramsMatch("software-system-groups/default", diagrams)
     }
+
+    @Test
+    fun test_C4Person() {
+        val workspace = parseWorkspace(testFile("c4-person/workspace.dsl"))
+        ThemeUtils.loadThemes(workspace)
+        val diagrams = D2Exporter().export(workspace)
+        assertEquals(2, diagrams.size)
+        assertAllDiagramsMatch("c4-person/default", diagrams)
+    }
+
+    @Test
+    fun test_C4PersonViewSet() {
+        val workspace = parseWorkspace(testFile("c4-person-view-set/workspace.dsl"))
+        ThemeUtils.loadThemes(workspace)
+        val diagrams = D2Exporter().export(workspace)
+        assertEquals(2, diagrams.size)
+        assertAllDiagramsMatch("c4-person-view-set/default", diagrams)
+    }
 }

--- a/lib/src/test/resources/c4-person-view-set/default/SystemContext-default.d2
+++ b/lib/src/test/resources/c4-person-view-set/default/SystemContext-default.d2
@@ -1,0 +1,42 @@
+title: |`md
+  # Software System - System Context
+`| {
+  near: top-center
+}
+direction: down
+container_1: {
+  label: "User\n[Person]"
+  shape: c4_person
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+container_2: {
+  label: "Software System\n[Software System]"
+  shape: rectangle
+  tooltip: "My software system."
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+
+container_1 -> container_2: {
+  label: "Uses"
+  style: {
+    font-size: 24
+    opacity: 1.0
+    stroke: "#707070"
+    stroke-dash: 5
+    stroke-width: 2
+  }
+}

--- a/lib/src/test/resources/c4-person-view-set/default/SystemContext-disabled.d2
+++ b/lib/src/test/resources/c4-person-view-set/default/SystemContext-disabled.d2
@@ -1,0 +1,42 @@
+title: |`md
+  # Software System - System Context
+`| {
+  near: top-center
+}
+direction: down
+container_1: {
+  label: "User\n[Person]"
+  shape: person
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+container_2: {
+  label: "Software System\n[Software System]"
+  shape: rectangle
+  tooltip: "My software system."
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+
+container_1 -> container_2: {
+  label: "Uses"
+  style: {
+    font-size: 24
+    opacity: 1.0
+    stroke: "#707070"
+    stroke-dash: 5
+    stroke-width: 2
+  }
+}

--- a/lib/src/test/resources/c4-person-view-set/workspace.dsl
+++ b/lib/src/test/resources/c4-person-view-set/workspace.dsl
@@ -1,0 +1,33 @@
+workspace {
+
+    model {
+        user = person "User"
+        softwareSystem = softwareSystem "Software System" "My software system."
+        user -> softwareSystem "Uses"
+    }
+
+    views {
+        properties {
+            d2.use_c4_person true
+        }
+
+        systemContext softwareSystem "SystemContext-default" {
+            include *
+            autoLayout
+        }
+
+        systemContext softwareSystem "SystemContext-disabled" {
+            properties {
+                d2.use_c4_person false
+            }
+            include *
+            autoLayout
+        }
+
+        styles {
+            element "Person" {
+                shape Person
+            }
+        }
+    }
+}

--- a/lib/src/test/resources/c4-person/default/SystemContext-c4.d2
+++ b/lib/src/test/resources/c4-person/default/SystemContext-c4.d2
@@ -1,0 +1,42 @@
+title: |`md
+  # Software System - System Context
+`| {
+  near: top-center
+}
+direction: down
+container_1: {
+  label: "User\n[Person]"
+  shape: c4_person
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+container_2: {
+  label: "Software System\n[Software System]"
+  shape: rectangle
+  tooltip: "My software system."
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+
+container_1 -> container_2: {
+  label: "Uses"
+  style: {
+    font-size: 24
+    opacity: 1.0
+    stroke: "#707070"
+    stroke-dash: 5
+    stroke-width: 2
+  }
+}

--- a/lib/src/test/resources/c4-person/default/SystemContext-default.d2
+++ b/lib/src/test/resources/c4-person/default/SystemContext-default.d2
@@ -1,0 +1,42 @@
+title: |`md
+  # Software System - System Context
+`| {
+  near: top-center
+}
+direction: down
+container_1: {
+  label: "User\n[Person]"
+  shape: person
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+container_2: {
+  label: "Software System\n[Software System]"
+  shape: rectangle
+  tooltip: "My software system."
+  style: {
+    fill: "#dddddd"
+    font-color: "#000000"
+    font-size: 24
+    multiple: false
+    opacity: 1.0
+    stroke: "#9a9a9a"
+  }
+}
+
+container_1 -> container_2: {
+  label: "Uses"
+  style: {
+    font-size: 24
+    opacity: 1.0
+    stroke: "#707070"
+    stroke-dash: 5
+    stroke-width: 2
+  }
+}

--- a/lib/src/test/resources/c4-person/workspace.dsl
+++ b/lib/src/test/resources/c4-person/workspace.dsl
@@ -1,0 +1,29 @@
+workspace {
+
+    model {
+        user = person "User"
+        softwareSystem = softwareSystem "Software System" "My software system."
+        user -> softwareSystem "Uses"
+    }
+
+    views {
+        systemContext softwareSystem "SystemContext-default" {
+            include *
+            autoLayout
+        }
+
+        systemContext softwareSystem "SystemContext-c4" {
+            properties {
+                d2.use_c4_person true
+            }
+            include *
+            autoLayout
+        }
+
+        styles {
+            element "Person" {
+                shape Person
+            }
+        }
+    }
+}


### PR DESCRIPTION
When `d2.use_c4_person` is set on a view or a view set, the exporter will export structurizr `Person` and `Robot` shapes as d2 `c4_person` (instead of `person`).

The `c4_person` shape is supported in d2 since https://github.com/terrastruct/d2/pull/2397.